### PR TITLE
Add flag for disabling IPAPI

### DIFF
--- a/awesome_django_timezones/middleware.py
+++ b/awesome_django_timezones/middleware.py
@@ -28,9 +28,11 @@ class TimezonesMiddleware:
                 # cookie timezones are URI encoded
                 tz = unquote(tz)
             else:
-                # no cookie set, use IP API to lookup timezone and use that to set the cookie
-                ip_info = ipapi.location(ip=get_ip_address(request), key=getattr(settings, 'DJANGO_IPAPI_KEY', None))
-                tz = ip_info.get('timezone', None)
+                ipapi_disabled = getattr(settings, 'DJANGO_IPAPI_DISABLED', False)
+                if not ipapi_disabled:
+                    # no cookie set, use IP API to lookup timezone and use that to set the cookie
+                    ip_info = ipapi.location(ip=get_ip_address(request), key=getattr(settings, 'DJANGO_IPAPI_KEY', None))
+                    tz = ip_info.get('timezone', None)
 
             try:
                 # attempt to activate the timezone - this might be an invalid timezone

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,3 +3,5 @@ Configuration
 =============
 
 * If using a purchased plan from https://ipapi.co, you can specify ``DJANGO_IPAPI_KEY`` in your ``settings.py`` file to use your key.
+
+* You can disable IP lookups with IPAPI by setting ``DJANGO_IPAPI_DISABLED`` to ``True`` in ``settings.py``.


### PR DESCRIPTION
It would be useful to disable the ipapi integration instead of having to pay a subscription, especially in intensive integration testing (which is where I hit this issue).

This PR adds a setting:
`DJANGO_IPAPI_DISABLED`